### PR TITLE
fix: 🐛 Fix the rd cannot be used in non-win

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+import os from 'node:os';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 inquirer.prompt([
     {
@@ -19,5 +20,12 @@ inquirer.prompt([
 ]).then(answers => {
     let gitUrl = "\u56FD\u5185\u8DEF\u7EBF\u4E0B\u8F7D\u6A21\u677F" /* Type.domestic */ === answers.url ? 'https://gitee.com/chinafaker/nuxt-demo.git' : 'https://github.com/message163/nuxt-template.git';
     execSync(`git clone -b main ${gitUrl} ${answers.name}`);
-    execSync(`cd ${answers.name} && rd /S/Q .git`);
+    switch (os.platform()) {
+        case 'win32':
+            execSync(`cd ${answers.name} && rd /S/Q .git`);
+            break;
+        default:
+            execSync(`cd ${answers.name} && rm -rf .git`);
+            break;
+    }
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer'
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import {exec, execSync} from 'child_process'
+import os from 'node:os'
 
 import fs from 'fs'
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -26,5 +27,12 @@ inquirer.prompt([
 ]).then(answers => {
     let gitUrl = Type.domestic === answers.url ? 'https://gitee.com/chinafaker/nuxt-demo.git' : 'https://github.com/message163/nuxt-template.git'
     execSync(`git clone -b main ${gitUrl} ${answers.name}`)
-    execSync(`cd ${answers.name} && rd /S/Q .git`)
+    switch (os.platform()) {
+        case 'win32':
+            execSync(`cd ${answers.name} && rd /S/Q .git`)
+            break;
+        default:
+            execSync(`cd ${answers.name} && rm -rf .git`)
+            break;
+    }
 })


### PR DESCRIPTION
Problem: The rd command can only be used in windows, but using this package in linux will prompt that the rd command cannot be found
问题： rd 命令只能在 windows 中使用，在 linux 中使用该包会提示 找不到 rd 命令

Solution: Execute different commands by judging the system type
解决: 通过判断系统类型 执行不同 命令
